### PR TITLE
Change inject method so it works on every page load

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -17,10 +17,18 @@ const injectPinterestScript = (tall, round) => {
   addJS();
 };
 
-exports.onClientEntry = (args, pluginOptions) => {
-  const {
-    tall = true,
-    round = false,
-  } = pluginOptions;
-  injectPinterestScript(tall, round);
+let injectedPinterestScript = false
+
+exports.onRouteUpdate = (args, pluginOptions) => {
+  if (document.querySelector('[data-pin-do]') !== null) {
+    if (!injectedPinterestScript) {
+      const {
+        tall = true,
+        round = false,
+      } = pluginOptions;
+
+      injectPinterestScript(tall, round);
+      injectedPinterestScript = true;
+    }
+  }
 };


### PR DESCRIPTION
While working on adding support for Pinterest for [gatsby-remark-embedder](https://github.com/MichaelDeBoey/gatsby-remark-embedder/pull/73) we noticed that sometimes the rich embed wasn't being triggered until a refresh. This change aims to fix that, it was inspired in the way [gatsby-plugin-twitter](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter) adds their code. On my tests I got the rich embed 100% of the times.