### PR TITLE
Don't show bookmark button by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ plugins: [
       // Set to true to display a bigger button
       tall: true, // default
       // Set to true to hide the text and display only a round P button
-      round: false // default
+      round: false, // default
+      // Set to true to add bookmark button to images
+      imageHover: false, // default
     }
   }
 ];

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,10 +1,12 @@
-const injectPinterestScript = (tall, round) => {
+const injectPinterestScript = ({ tall, round, imageHover }) => {
   function addJS() {
     const s = document.createElement(`script`);
     s.type = `text/javascript`;
     s.setAttribute("async", "async");
     s.setAttribute("defer", "defer");
+    if(imageHover) {
       s.setAttribute("data-pin-hover", "true");
+    }
     if(tall) {
       s.setAttribute("data-pin-tall", "true");
     }
@@ -20,14 +22,21 @@ const injectPinterestScript = (tall, round) => {
 let injectedPinterestScript = false
 
 exports.onRouteUpdate = (args, pluginOptions) => {
-  if (document.querySelector('[data-pin-do]') !== null) {
-    if (!injectedPinterestScript) {
-      const {
-        tall = true,
-        round = false,
-      } = pluginOptions;
+  const {
+    tall = true,
+    round = false,
+    imageHover = false,
+  } = pluginOptions;
 
-      injectPinterestScript(tall, round);
+  const selectors = ['[data-pin-do]'];
+
+  if (imageHover) {
+    selectors.push('img');
+  }
+
+  if (document.querySelector(selectors.join(',')) !== null) {
+    if (!injectedPinterestScript) {
+      injectPinterestScript({ tall, round, imageHover });
       injectedPinterestScript = true;
     }
   }


### PR DESCRIPTION
By default don't show bookmark button on images, user can opt-in to that. If they do and even if there are no rich embeds, they still see the bookmark button.

Fixes #4

Example:
[![Edit festive-jennings-3jiyx](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/festive-jennings-3jiyx?fontsize=14&hidenavigation=1&theme=dark)