### PR TITLE
chore: Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: npm
 notifications:
   email: false
 node_js:
-  - 10.18
+  - 10.13
   - 12
   - node
 install: npm install
@@ -13,7 +13,7 @@ script:
 branches:
   only:
     - master
-    - next
+    - beta
 
 jobs:
   include:

--- a/package.json
+++ b/package.json
@@ -33,17 +33,17 @@
     "validate": "kcd-scripts validate"
   },
   "dependencies": {
-    "@babel/runtime": "^7.8.4"
+    "@babel/runtime": "^7.8.7"
   },
   "devDependencies": {
     "all-contributors-cli": "^6.14.0",
-    "kcd-scripts": "^5.2.0"
+    "kcd-scripts": "^5.4.0"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0"
+    "gatsby": "^2.20.0"
   },
   "engines": {
-    "node": ">=10.18",
+    "node": ">=10.13.0",
     "npm": ">=6",
     "yarn": ">=1"
   }


### PR DESCRIPTION
BREAKING CHANGE: `node@>=10.13.0` is required
BREAKING CHANGE: `gatsby@^2.20.0` is required

https://gatsbyjs.org/blog/2020-03-20-dropping-support-for-node-8