### PR TITLE
fix(ci): disable npm cache in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
-cache: npm
+cache:
+  npm: false
 notifications:
   email: false
 node_js:


### PR DESCRIPTION
This PR disables npm cache in Travis as a temporary solution to solve #16.

This is not optimal because it will make build times much longer, but it seems that the issue we have is caused by outdated dependencies.

Closes #16 