### PR TITLE
fix: disable CI runs on node@latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
-cache:
-  npm: false
 notifications:
   email: false
 node_js:
@@ -8,7 +6,6 @@ node_js:
   - 10
   - 12
   - 14
-  - node
 install: npm install
 script:
   - npm run validate


### PR DESCRIPTION
This node version is causing issues with cache and timeouts in Travis. Disabling for now, tests will only run on fixed node versions until further notice.