### PR TITLE
Move script to body instead of head

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -19,7 +19,7 @@ const injectPinterestScript = ({ saveButton = false }) => {
       }
     }
 
-    document.getElementsByTagName("head")[0].appendChild(script);
+    document.getElementsByTagName("body")[0].appendChild(script);
   };
 
   addJS();


### PR DESCRIPTION
Was running into some issues (unrelated to this plugin) and noticed that according to [the docs](https://developers.pinterest.com/docs/widgets/getting-started/#helpful-hints) the script should be in the body tag, not the head tag! I've tested this locally and while I haven't actually noticed a difference in behavior it does not seem to change behavior of the plugin.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: move pinit script to body instead of head

<!-- Why are these changes necessary? -->

**Why**: the docs say "You’ll run into trouble if you place our script tag somewhere else, like in: The document’s head" and we sure don't want trouble!

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
