### PR TITLE
Manually trigger script for non-hover use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 
 - [Installation](#installation)
 - [Usage](#usage)
+  - [Show Save Button on hover](#show-save-button-on-hover)
+  - [Manually show Save Button](#manually-show-save-button)
 - [Inspiration](#inspiration)
 - [Issues](#issues)
   - [🐛 Bugs](#-bugs)
@@ -51,6 +53,14 @@ This library has a `peerDependencies` listing for [`gatsby`][gatsby].
 
 ## Usage
 
+Use the `options` to configure the script with
+[available attributes](https://developers.pinterest.com/docs/widgets/save/?#button-style-settings).
+
+Note: not all attributes are supported in the plugin yet.
+[See issues for more details](https://github.com/robinmetral/gatsby-plugin-pinterest/issues).
+
+### Show Save Button on hover
+
 ```js
 // In your gatsby-config.js
 
@@ -61,6 +71,7 @@ module.exports = {
       resolve: `gatsby-plugin-pinterest`,
       options: {
         // If you just want to use the default, you can set this to `true`, defaults to `false`
+        // This sets the data-pin-hover attribute in the script
         saveButton: {
           // Set to true to hide the text and display only a round P button
           round: false, // default
@@ -74,6 +85,45 @@ module.exports = {
   ],
 };
 ```
+
+### Manually show Save Button
+
+```js
+// In your gatsby-config.js
+
+module.exports = {
+  // Find the 'plugins' array
+  plugins: [
+    {
+      resolve: `gatsby-plugin-pinterest`,
+    },
+    // Other plugins here...
+  ],
+};
+```
+
+Then in your code:
+
+```js
+const pinType = "buttonPin"; // for one image or "buttonBookmark" for any image
+
+// Optional parameters
+// Source settings. See: https://developers.pinterest.com/docs/widgets/save/?#button-style-settings
+const url = "https://mysite.com/sourdough-dinner-rolls";
+const description = `&description="this is my favorite recipe for sourdough dinner rolls"`;
+const mediaUrl =
+  pinType === "buttonPin"
+    ? `&media=https://mysite.com/images/dinner-rolls.png`
+    : ""; // don't supply the mediaUrl for buttonBookmark
+
+const to = `https://www.pinterest.com/pin/create/button/?url=${url}${description}${mediaUrl}`;
+
+// Add this to your component where you want the button to appear
+return <a href={to} target="_blank" rel="noreferrer" data-pin-do={pinType} />;
+```
+
+Manually add source settings like `url`, `description`, and `mediaUrl` since
+[gatsby-image doesn't support custom image attributes](https://github.com/robinmetral/gatsby-plugin-pinterest/issues/30).
 
 ## Inspiration
 
@@ -118,6 +168,7 @@ Thanks goes to these wonderful people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -28,9 +28,11 @@ const injectPinterestScript = ({ saveButton = false }) => {
 let injectedPinterestScript = false;
 
 exports.onRouteUpdate = (args, pluginOptions = {}) => {
+  const hover = Boolean(pluginOptions.saveButton)
+
   const querySelectors = [
     "[data-pin-do]",
-    Boolean(pluginOptions.saveButton) ? "img" : "",
+    hover ? "img" : "",
   ]
     .filter(Boolean)
     .join(",");
@@ -40,6 +42,14 @@ exports.onRouteUpdate = (args, pluginOptions = {}) => {
       injectPinterestScript(pluginOptions);
 
       injectedPinterestScript = true;
+    }
+
+    if (
+      !hover &&
+      typeof PinUtils !== `undefined` &&
+      typeof window.PinUtils.build === `function`
+    ) {
+      window.PinUtils.build()
     }
   }
 };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: 
Fixes #28 

Manually triggers PinUtils.build() for non-hover use cases (hover use case works with existing plugin code).

<!-- Why are these changes necessary? -->

**Why**: 
Without this, the script only works on page refresh due to the way Gatsby loads 3rd party scripts. There is a similar workaround in the [Twitter plugin](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-twitter/src/gatsby-browser.js#L46) and a delay in the [Google Analytics plugin](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js#L24)

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

This feels like a hack since the PinUtils.build() function isn't explicitly documented, but I've tried a lot of different things to make this work and this is the best option I've found. At the very least it's [consistent with the Twitter plugin which is blessed by Gatsby.](https://github.com/gatsbyjs/gatsby/issues/4983#issuecomment-381365516)